### PR TITLE
feat: add longest message reply chain search

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -103,6 +103,7 @@ pub struct ChatStats {
     pub participants: HashMap<String, UserStats>,
     pub text_entity_types: HashMap<String, u64>,
     pub settings: StatsSettings,
+    pub longest_chain: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -146,6 +147,8 @@ impl ChatStats {
                 im.add_message(id, msg);
             }
         }
+
+        self.longest_chain = format!("{:#?}", im.longest_chain());
     }
 
     fn count_entities(&mut self, entities: &[crate::TextEntity]) {
@@ -220,6 +223,8 @@ impl fmt::Display for ChatStats {
             writeln!(f, "\n📏 Combined Participant Stats:")?;
             self.display_user_stats(&combined, f)?;
         }
+
+        writeln!(f, "Longest chain: {}", self.longest_chain)?;
 
         if !self.participants.is_empty() {
             let max = self.settings.max_participants;


### PR DESCRIPTION
Add longest message reply chain computation to IndexedMessages

- Introduced `IndexedMessages::add_message()` to store messages and track reply chain lengths.
- Added `IndexedMessages::longest_chain()` to find the longest reply chain based on message count.
- Displayed the longest chain in `ChatStats` output for analysis/debugging.
